### PR TITLE
Fully set elements when updating a slot

### DIFF
--- a/Assets/Plugins/SpineSprite/GSpineAttachment.cs
+++ b/Assets/Plugins/SpineSprite/GSpineAttachment.cs
@@ -40,7 +40,7 @@ public class GSpineAttachment : FSprite {
 	public void Update(Slot slot){
 		_attachment = slot.Attachment as RegionAttachment;
 		_attachment.UpdateVertices(slot.Bone);
-		_element = _attachment.Texture as FAtlasElement;
+		element = _attachment.Texture as FAtlasElement;
 		
 		base.color = _slotCustomColor * new Color(slot.R, slot.G, slot.B, slot.A);
 		


### PR DESCRIPTION
This fixes issue GeorgeJurcich/Futile-SpineSprite#1 by setting the element using the public setter instead of setting the private member.
