### PR TITLE
Use Futile.white to allow custom 'white' color

### DIFF
--- a/Assets/Plugins/SpineSprite/GSpineAttachment.cs
+++ b/Assets/Plugins/SpineSprite/GSpineAttachment.cs
@@ -26,7 +26,7 @@ public class GSpineAttachment : FSprite {
 	}
 	
 	// this is the runtime tint color to mix with the attachment color.
-	private Color _slotCustomColor = Color.white;
+	private Color _slotCustomColor = Futile.white;
 	override public Color color {
 		get {
 			return _slotCustomColor;	

--- a/Assets/Plugins/SpineSprite/GSpineSlot.cs
+++ b/Assets/Plugins/SpineSprite/GSpineSlot.cs
@@ -23,7 +23,7 @@ public class GSpineSlot : FContainer {
 	}
 	
 	// the color to apply to the attachment on this slot.
-	private Color _color = Color.white;
+	private Color _color = Futile.white;
 	public Color color {
 		get {
 			return _color;	


### PR DESCRIPTION
Use Futile.white to allow custom 'white' color (for example when using custom Futile shaders that multiply the color).

Futile.white defaults to Color.white, so this doesn't change the default behaviour.
